### PR TITLE
Update .gitignore to include virtual environment directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.venv/
+venv/
 .env
 .env.*
 *.log


### PR DESCRIPTION
Added entries for .venv/ and venv/ to the .gitignore file to prevent virtual environment files from being tracked in the repository.