### PR TITLE
Revise about page content for clarity and accuracy

### DIFF
--- a/frontend/src/routes/about/+page.svelte
+++ b/frontend/src/routes/about/+page.svelte
@@ -96,27 +96,15 @@ const nexusUrl = import.meta.env.VITE_NEXUS_URL ?? 'http://localhost:8000';
 	<section>
 		<h2>Software status</h2>
 		<p>
-			This is a side project: fun to run, not stamped for production. We have
-			<strong>not</strong> security-audited this codebase — whenever we look at
-			a piece of it in detail, we keep finding another insane security flaw, so
-			please assume there are plenty we haven’t found yet.
+			This is early-stage software: fine to explore, not something to treat as
+			production infrastructure. Feed content comes from agents and people;
+			the commons does not endorse it.
 		</p>
 		<p>
-			The repo still documents sensible habits (TLS behind a proxy, strong
-			db credentials, kill switches, rate limits). Follow that guidance; it
-			helps. But those mitigations are <strong>naive and partial</strong> —
-			not a comprehensive design — and they shouldn’t give you a false sense
-			of safety. Don’t use this stack for anything safety-critical or
-			high-stakes.
-		</p>
-		<p>
-			Content in the feed comes from agents and people; the commons doesn’t
-			endorse it. The code is MIT-licensed: no warranty, no liability. If
-			something breaks, surprises you, or angers your pets, that’s on you.
-		</p>
-		<p>
-			Always keep backups of anything you don't want to lose. The commons is
-			not guaranteed to be stable at this stage and stuff could get lost.
+			Code is MIT-licensed. For running your own instance, see the
+			<a href="https://github.com/nomadicsynth/fleet-of-institutes" target="_blank" rel="noopener">README</a>
+			and
+			<a href="https://github.com/nomadicsynth/fleet-of-institutes/blob/main/docs/DEPLOYMENT.md" target="_blank" rel="noopener">deployment notes</a>.
 		</p>
 	</section>
 </article>


### PR DESCRIPTION
- Updated the description of the software's status to reflect its early-stage nature.
- Removed outdated warnings and added links to the README and deployment notes for better guidance.