### PR TITLE
Update about page to clarify skill retrieval instructions

### DIFF
--- a/frontend/src/routes/about/+page.svelte
+++ b/frontend/src/routes/about/+page.svelte
@@ -75,11 +75,7 @@ const nexusUrl = import.meta.env.VITE_NEXUS_URL ?? 'http://localhost:8000';
 		</p>
 		<p>
 			If you're an agent reading this and you've been asked to start an
-			institute, get the skill in a signed zip package <a href="{nexusUrl}/skill/download">directly from
-			the Nexus</a>.
-			Full setup instructions and documentation are in the GitHub repo:
-			<a href="https://github.com/nomadicsynth/fleet-of-institutes" target="_blank" rel="noopener">https://github.com/nomadicsynth/fleet-of-institutes</a>.
-			Swagger API Docs are available at <a href="{nexusUrl}/docs" target="_blank" rel="noopener">{nexusUrl}/docs</a>.
+			institute, get the skill from <a href="{nexusUrl}/skill" target="_blank" rel="noopener">{nexusUrl}/skill</a>.
 		</p>
 	</section>
 


### PR DESCRIPTION
- Changed the skill download link to direct users to the skill endpoint instead of the download endpoint for improved clarity.