### PR TITLE
Fix paper page Markdown rendering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
 				"@sveltejs/kit": "^2.57.1",
 				"@sveltejs/mcp": "^0.1.22",
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
+				"@types/markdown-it": "^14.1.2",
 				"svelte": "^5.55.4",
 				"svelte-check": "^4.4.6",
 				"typescript": "^5.9.3",
@@ -710,6 +711,31 @@
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/markdown-it": {
+			"version": "14.1.2",
+			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+			"integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/linkify-it": "^5",
+				"@types/mdurl": "^2"
+			}
+		},
+		"node_modules/@types/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "frontend",
 			"version": "0.0.1",
 			"dependencies": {
-				"@sveltejs/adapter-static": "^3.0.10"
+				"@sveltejs/adapter-static": "^3.0.10",
+				"markdown-it": "^14.1.1"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^7.0.0",
@@ -790,7 +791,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
 			"license": "Python-2.0"
 		},
 		"node_modules/aria-query": {
@@ -980,6 +980,18 @@
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
 			"integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
 			"license": "MIT"
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -1702,6 +1714,15 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -1739,6 +1760,29 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
+		},
+		"node_modules/markdown-it": {
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+			"integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"license": "MIT"
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.5",
@@ -1958,6 +2002,15 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -2241,6 +2294,12 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"license": "MIT"
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
 		"@sveltejs/kit": "^2.57.1",
 		"@sveltejs/mcp": "^0.1.22",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
+		"@types/markdown-it": "^14.1.2",
 		"svelte": "^5.55.4",
 		"svelte-check": "^4.4.6",
 		"typescript": "^5.9.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
 		"vite": "^8.0.8"
 	},
 	"dependencies": {
-		"@sveltejs/adapter-static": "^3.0.10"
+		"@sveltejs/adapter-static": "^3.0.10",
+		"markdown-it": "^14.1.1"
 	}
 }

--- a/frontend/src/routes/paper/[id]/+page.svelte
+++ b/frontend/src/routes/paper/[id]/+page.svelte
@@ -300,8 +300,8 @@
 		margin-bottom: 0;
 	}
 	.body :global(pre) {
-		background: #f4f4f5;
-		border: 1px solid #e4e4e7;
+		background: var(--bg);
+		border: 1px solid var(--border);
 		border-radius: 8px;
 		padding: 0.8rem;
 		overflow-x: auto;

--- a/frontend/src/routes/paper/[id]/+page.svelte
+++ b/frontend/src/routes/paper/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageProps } from './$types';
 	import { onMount } from 'svelte';
+	import MarkdownIt from 'markdown-it';
 	import { getPaper, getLocalNexusId, formatInstituteAttribution, type Paper } from '$lib/api';
 	import Avatar from '$lib/components/Avatar.svelte';
 	import ReactionBadge from '$lib/components/ReactionBadge.svelte';
@@ -10,6 +11,11 @@
 	let paper = $state<Paper | null>(null);
 	let localNexusId = $state('');
 	let error = $state('');
+	const markdown = new MarkdownIt({
+		html: false,
+		linkify: true,
+		breaks: true
+	});
 
 	onMount(async () => {
 		try {
@@ -54,6 +60,9 @@
 		}
 		return counts;
 	});
+	const renderedContent = $derived(
+		paper?.content ? markdown.render(paper.content) : ''
+	);
 </script>
 
 <svelte:head>
@@ -131,7 +140,7 @@
 
 		{#if paper.content}
 			<section class="body">
-				<p>{paper.content}</p>
+				{@html renderedContent}
 			</section>
 		{/if}
 
@@ -281,9 +290,35 @@
 		font-style: italic;
 		color: var(--text-secondary);
 	}
-	.body p {
-		white-space: pre-wrap;
+	.body :global(*) {
 		line-height: 1.7;
+	}
+	.body :global(p:first-child) {
+		margin-top: 0;
+	}
+	.body :global(p:last-child) {
+		margin-bottom: 0;
+	}
+	.body :global(pre) {
+		background: #f4f4f5;
+		border: 1px solid #e4e4e7;
+		border-radius: 8px;
+		padding: 0.8rem;
+		overflow-x: auto;
+	}
+	.body :global(code) {
+		font-family: 'IBM Plex Mono', monospace;
+		font-size: 0.9em;
+	}
+	.body :global(blockquote) {
+		margin: 1rem 0;
+		padding: 0.5rem 0.9rem;
+		border-left: 3px solid var(--border);
+		color: var(--text-secondary);
+	}
+	.body :global(ul),
+	.body :global(ol) {
+		padding-left: 1.2rem;
 	}
 	.refs ul {
 		list-style: none;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- render paper body as Markdown on the frontend paper detail page instead of plain text
- use `markdown-it` with `html: false` to prevent raw HTML injection while still supporting Markdown formatting
- add markdown-aware styling for common elements (lists, code blocks, blockquotes)
- add `@types/markdown-it` so Svelte type checking passes

## Testing
- `npm run check` in `frontend`
- manual browser verification on `http://localhost:5173/paper/2604.8de32d30` with `VITE_NEXUS_URL=https://api.fleetofinstitutes.org`

## Walkthrough artifacts
[issue_37_markdown_rendering_walkthrough.mp4](https://cursor.com/agents/bc-6a3ffc2b-2452-432d-81ef-4588b2b8c180/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_37_markdown_rendering_walkthrough.mp4)
[Markdown rendering top section](https://cursor.com/agents/bc-6a3ffc2b-2452-432d-81ef-4588b2b8c180/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_37_markdown_render_top.webp)
[Markdown list rendering](https://cursor.com/agents/bc-6a3ffc2b-2452-432d-81ef-4588b2b8c180/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_37_markdown_render_list.webp)
[Markdown references rendering](https://cursor.com/agents/bc-6a3ffc2b-2452-432d-81ef-4588b2b8c180/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_37_markdown_render_references.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a3ffc2b-2452-432d-81ef-4588b2b8c180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a3ffc2b-2452-432d-81ef-4588b2b8c180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

