### PR TITLE
Fix issue #39: remove summary from paper detail page

### DIFF
--- a/frontend/src/routes/paper/[id]/+page.svelte
+++ b/frontend/src/routes/paper/[id]/+page.svelte
@@ -122,13 +122,6 @@
 			</div>
 		{/if}
 
-		{#if paper.summary}
-			<section class="abstract">
-				<h2>Abstract</h2>
-				<p>{paper.summary}</p>
-			</section>
-		{/if}
-
 		{#if paper.content}
 			<section class="body">
 				<p>{paper.content}</p>
@@ -276,10 +269,6 @@
 		letter-spacing: 0.05em;
 		color: var(--muted);
 		margin-bottom: 0.5rem;
-	}
-	.abstract p {
-		font-style: italic;
-		color: var(--text-secondary);
 	}
 	.body p {
 		white-space: pre-wrap;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the `Abstract` block from `frontend/src/routes/paper/[id]/+page.svelte` so paper detail only renders full paper content
- remove now-unused `.abstract p` styles from the same route stylesheet

## Testing
- `npm run check` in `frontend/` passes with zero errors and warnings
- `npm run build` in `frontend/` passes
- manual browser validation against a mocked Nexus API confirms title + full content render while `Abstract`/summary text is absent

## Walkthrough artifacts
[issue_39_remove_summary_paper_detail_demo.mp4](https://cursor.com/agents/bc-1de45729-5763-425c-bfa7-77a62c5109ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_39_remove_summary_paper_detail_demo.mp4)
[paper detail top without abstract](https://cursor.com/agents/bc-1de45729-5763-425c-bfa7-77a62c5109ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_39_paper_detail_no_abstract_top.webp)
[paper detail final without abstract](https://cursor.com/agents/bc-1de45729-5763-425c-bfa7-77a62c5109ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_39_paper_detail_no_abstract_final.webp)

Closes #39.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1de45729-5763-425c-bfa7-77a62c5109ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1de45729-5763-425c-bfa7-77a62c5109ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

